### PR TITLE
Add Multi-Model Image Generation Support

### DIFF
--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -25,16 +25,17 @@ except Exception as e:
     logger.error(f"Failed to initialize Sora 2 client: {str(e)}")
     sora_client = None
 
-# Initialize GPT-Image-1 client
+# Initialize GPT-Image client (using default model)
 try:
-    # Using OpenAI API directly for GPT-Image-1
+    # Using OpenAI API directly for GPT-Image
     dalle_client = GPTImageClient(
         api_key=settings.OPENAI_API_KEY,
-        organization_id=settings.OPENAI_ORG_ID if settings.OPENAI_ORG_ID else None
+        organization_id=settings.OPENAI_ORG_ID if settings.OPENAI_ORG_ID else None,
+        model=settings.DEFAULT_IMAGE_MODEL
     )
-    logger.info("Initialized GPT-Image-1 client using OpenAI API.")
+    logger.info(f"Initialized GPT-Image client using OpenAI API with default model: {settings.DEFAULT_IMAGE_MODEL}")
 except Exception as e:
-    logger.error(f"Failed to initialize GPT-Image-1 client: {str(e)}")
+    logger.error(f"Failed to initialize GPT-Image client: {str(e)}")
     dalle_client = None
 
 # Initialize LLM client (sync)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -25,10 +25,16 @@ class Settings(BaseSettings):
     # Azure OpenAI for Image Generation
     # The Azure OpenAI resource name for image generation
     IMAGEGEN_AOAI_RESOURCE: Optional[str] = None
-    # The image generation deployment name
+    # The image generation deployment name (gpt-image-1)
     IMAGEGEN_DEPLOYMENT: Optional[str] = None
+    # The gpt-image-1.5 deployment name
+    IMAGEGEN_15_DEPLOYMENT: Optional[str] = None
+    # The gpt-image-1-mini deployment name
+    IMAGEGEN_1_MINI_DEPLOYMENT: Optional[str] = None
     # The Azure OpenAI API key for image generation
     IMAGEGEN_AOAI_API_KEY: Optional[str] = None
+    # Default image generation model
+    DEFAULT_IMAGE_MODEL: str = "gpt-image-1"
 
     # OpenAI API for Image Generation with GPT-Image-1
     OPENAI_API_KEY: Optional[str] = None

--- a/backend/models/images.py
+++ b/backend/models/images.py
@@ -45,7 +45,15 @@ class ImageGenerationRequest(BaseModel):
                         examples=["A futuristic city skyline at sunset"])
     model: str = Field("gpt-image-1",
                        description="Image generation model to use",
-                       examples=["gpt-image-1"])
+                       examples=["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini"])
+    
+    @validator('model')
+    def validate_model(cls, v):
+        """Validate that the model is one of the supported models"""
+        valid_models = ["gpt-image-1", "gpt-image-1.5", "gpt-image-1-mini"]
+        if v not in valid_models:
+            raise ValueError(f"Model must be one of {valid_models}")
+        return v
     n: int = Field(1,
                    description="Number of images to generate (1-10)")
     size: str = Field("auto",

--- a/frontend/components/ImageCreationContainer.tsx
+++ b/frontend/components/ImageCreationContainer.tsx
@@ -22,6 +22,7 @@ interface ImageCreationContainerProps {
 
 interface ImageGenerationSettings {
   prompt: string;
+  model: string;
   imageSize: string;
   saveImages: boolean;
   mode: string;
@@ -184,7 +185,8 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
           newSettings.variations, // Number of variations from dropdown
           newSettings.imageSize, // Use selected size
           newSettings.quality, // Quality parameter
-          newSettings.inputFidelity // Input fidelity parameter
+          newSettings.inputFidelity, // Input fidelity parameter
+          newSettings.model // Model parameter
         );
         
         // Update the loading toast to success
@@ -208,7 +210,7 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
             output_format: newSettings.outputFormat,
             background: newSettings.background,
             folder_path: normalizedFolder,
-            model: 'gpt-image-1',
+            model: newSettings.model,
             analyze: true,
             save_all: true,
           });
@@ -238,7 +240,8 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
             "b64_json",
             newSettings.background,
             newSettings.outputFormat,
-            newSettings.quality
+            newSettings.quality,
+            newSettings.model
           );
           toast.success("Image generation completed", {
             id: generatingToast,
@@ -265,7 +268,8 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
           normalizedFolder,
           newSettings.outputFormat,
           newSettings.background,
-          newSettings.imageSize
+          newSettings.imageSize,
+          newSettings.model
         );
       }
       
@@ -333,6 +337,7 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
     outputFormat: string = "png",
     background: string = "auto",
     imageSize: string,
+    model: string = "gpt-image-1",
     preAnalysisResults?: ImageAnalysis[] 
   ) => {
     try {
@@ -376,7 +381,7 @@ export function ImageCreationContainer({ className = "", onImagesSaved }: ImageC
         true, // Save all generated images
         folder, // Folder path
         outputFormat, // Output format
-        "gpt-image-1", // Model - This is always gpt-image-1 in our current implementation
+        model, // Model from parameter
         background, // Background setting
         imageSize, // Pass imageSize here
         shouldAnalyze // Analyze images in the backend if we have pre-analysis results

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1154,12 +1154,13 @@ export async function generateImages(
   response_format: string = "b64_json",
   background: string = "auto",
   outputFormat: string = "png",
-  quality: string = "auto"
+  quality: string = "auto",
+  model: string = "gpt-image-1"
 ): Promise<ImageGenerationResponse> {
   const pipelineRequest: ImagePipelineRequest = {
     action: PipelineAction.GENERATE,
     prompt,
-    model: 'gpt-image-1',
+    model,
     n,
     size,
     response_format,
@@ -1627,6 +1628,7 @@ export async function moveAsset(
  * @param inputFidelity - Input fidelity for better reproduction of input features:
  *   - 'low' (default): Standard fidelity, faster processing
  *   - 'high': Better reproduction of input image features, additional cost (~$0.04-$0.06 per image)
+ * @param model - Image generation model to use (default: "gpt-image-1")
  */
 export async function editImage(
   sourceImages: File | File[],
@@ -1634,7 +1636,8 @@ export async function editImage(
   n: number = 1,
   size: string = "auto",
   quality: string = "auto",
-  inputFidelity: string = "low"
+  inputFidelity: string = "low",
+  model: string = "gpt-image-1"
 ): Promise<ImageGenerationResponse> {
   if (inputFidelity && !["low", "high"].includes(inputFidelity)) {
     throw new Error("input_fidelity must be either 'low' or 'high'");
@@ -1643,13 +1646,13 @@ export async function editImage(
   const filesArray = Array.isArray(sourceImages) ? sourceImages : [sourceImages];
 
   if (API_DEBUG) {
-    console.log(`Editing ${filesArray.length} image(s) with prompt: ${prompt}, input_fidelity: ${inputFidelity}`);
+    console.log(`Editing ${filesArray.length} image(s) with prompt: ${prompt}, model: ${model}, input_fidelity: ${inputFidelity}`);
   }
 
   const pipelineRequest: ImagePipelineRequest = {
     action: PipelineAction.EDIT,
     prompt,
-    model: 'gpt-image-1',
+    model,
     n,
     size,
     response_format: 'b64_json',

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,8 +37,12 @@ param LLM_AOAI_API_KEY string
 // Parameters for the OpenAI deployments - Image Generation
 @description('Name of the Azure OpenAI resource for image generation')
 param IMAGEGEN_AOAI_RESOURCE string
-@description('Name of the image generation deployment')
+@description('Name of the image generation deployment (gpt-image-1)')
 param IMAGEGEN_DEPLOYMENT string
+@description('Name of the gpt-image-1.5 deployment')
+param IMAGEGEN_15_DEPLOYMENT string = ''
+@description('Name of the gpt-image-1-mini deployment')
+param IMAGEGEN_1_MINI_DEPLOYMENT string = ''
 @secure()
 @description('API key for image generation Azure OpenAI service')
 param IMAGEGEN_AOAI_API_KEY string
@@ -203,6 +207,8 @@ module containerAppBackend './modules/containerApp.bicep' = {
     AZURE_CONTAINER_REGISTRY_PASSWORD: containerRegistryMod.outputs.containerRegistryPassword
     IMAGEGEN_AOAI_RESOURCE: IMAGEGEN_AOAI_RESOURCE
     IMAGEGEN_DEPLOYMENT: IMAGEGEN_DEPLOYMENT
+    IMAGEGEN_15_DEPLOYMENT: IMAGEGEN_15_DEPLOYMENT
+    IMAGEGEN_1_MINI_DEPLOYMENT: IMAGEGEN_1_MINI_DEPLOYMENT
     IMAGEGEN_AOAI_API_KEY: IMAGEGEN_AOAI_API_KEY
     LLM_AOAI_RESOURCE: LLM_AOAI_RESOURCE
     LLM_DEPLOYMENT: LLM_DEPLOYMENT
@@ -242,6 +248,8 @@ module containerAppFrontend './modules/containerApp.bicep' = {
     AZURE_CONTAINER_REGISTRY_PASSWORD: containerRegistryMod.outputs.containerRegistryPassword
     IMAGEGEN_AOAI_RESOURCE: IMAGEGEN_AOAI_RESOURCE
     IMAGEGEN_DEPLOYMENT: IMAGEGEN_DEPLOYMENT
+    IMAGEGEN_15_DEPLOYMENT: IMAGEGEN_15_DEPLOYMENT
+    IMAGEGEN_1_MINI_DEPLOYMENT: IMAGEGEN_1_MINI_DEPLOYMENT
     IMAGEGEN_AOAI_API_KEY: IMAGEGEN_AOAI_API_KEY
     LLM_AOAI_RESOURCE: LLM_AOAI_RESOURCE
     LLM_DEPLOYMENT: LLM_DEPLOYMENT

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -35,6 +35,12 @@
     "IMAGEGEN_DEPLOYMENT": {
       "value": "${IMAGEGEN_DEPLOYMENT}"
     },
+    "IMAGEGEN_15_DEPLOYMENT": {
+      "value": "${IMAGEGEN_15_DEPLOYMENT}"
+    },
+    "IMAGEGEN_1_MINI_DEPLOYMENT": {
+      "value": "${IMAGEGEN_1_MINI_DEPLOYMENT}"
+    },
     "SORA_AOAI_RESOURCE": {
       "value": "${SORA_AOAI_RESOURCE}"
     },


### PR DESCRIPTION
## Summary
Adds support for `GPT-Image-1`, `GPT-Image-1.5`, and `GPT-Image-1 Mini` models with proper deployment tracking and cost attribution.
## Key Changes

### Backend:
- ✨ Added model selection parameter to GPTImageClient with automatic Azure deployment mapping
- ✨ Added deployment name tracking in Cosmos DB metadata for cost analysis
- 🛡️ Implemented validation to block GPT-Image-1 Mini from editing operations (not supported)
- ⚙️ Added environment variables: IMAGEGEN_15_DEPLOYMENT, IMAGEGEN_1_MINI_DEPLOYMENT
### Frontend:
- 🎨 Added model selection dropdown with clean UI (name only in trigger, descriptions in menu)
- 🎚️ Added collapsible "Advanced Settings" for folder selection and AI analysis toggle
- ⚠️ Added warning alert when mini model is selected with edit mode
- 🔒 Disabled submit when mini model + source images are selected
### Infrastructure:
- 📋 Updated Bicep templates and parameters to support new deployment variables